### PR TITLE
Added Controller for route:cache

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,6 @@
 <?php
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Route;
+use PeterBrinck\NovaLaravelNews\Http\Controllers\NewsController;
 
 /*
 |--------------------------------------------------------------------------
@@ -15,10 +13,4 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('news', function (Request $request) {
-    $data = Cache::remember('laravel-news::news', 60, function () {
-        $rss = new SimpleXmlElement(file_get_contents('https://feed.laravel-news.com/'));
-        return json_encode($rss);
-    });
-    return response()->json($data);
-});
+Route::get('news', NewsController::class . '@index');

--- a/src/Http/Controllers/NewsController.php
+++ b/src/Http/Controllers/NewsController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PeterBrinck\NovaLaravelNews\Http\Controllers;
+
+use Illuminate\Support\Facades\Cache;
+
+class NewsController
+{
+    public function index()
+    {
+        $data = Cache::remember('laravel-news::news', 60, function () {
+            $rss = new \SimpleXmlElement(file_get_contents('https://feed.laravel-news.com/'));
+            return json_encode($rss);
+        });
+        return response()->json($data);
+    }
+}


### PR DESCRIPTION
Since I need to use Route:cache and needed to remove the closure in api.php

I had the error: "Unable to prepare route [nova-vendor/nova-laravel-news/news] for serialization."